### PR TITLE
Bugfix/bad next calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ export const compositeReducer = compose([errorHandler, reduxLogger, reducer]);
 ```
 
 ### `withDefault(defaultState)`
-Returns a reducer that returns the supplied `defaultState` if the `state` it's supplied is `undefined`
+Returns a reducer that returns the supplied `defaultState` if the `state` its supplied is `undefined`
 
 ```js
 import { withDefault } from "horux";

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "horux",
   "version": "4.0.2",
   "description": "A library of simple everyday reducer utility functions ",
+  "keywords": ["redux", "reducer", "compose", "higher-order functions"],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",

--- a/src/map-by-type.ts
+++ b/src/map-by-type.ts
@@ -10,11 +10,11 @@ const mapByType = <TState, TAction extends { type: string }>(
       throw new Error(`Key "${key}" in mapByType is not a reducer`);
     }
   }
-  return (state, action: TAction, next) => {
+  return (state, action: TAction) => {
     if (!action.type || typeof reducers[action.type] === "undefined") {
       return state;
     }
-    return reducers[action.type](state, action, next);
+    return reducers[action.type](state, action);
   };
 };
 

--- a/src/merge-states.ts
+++ b/src/merge-states.ts
@@ -3,8 +3,8 @@ import { ComposableReducer } from "./types/composableReducer";
 const mergeStates = <TState, TAction>(
   reducer: ComposableReducer<TState, TAction>
 ): ComposableReducer<TState, TAction> => {
-  return (state, action, next) => {
-    const nextState = reducer(state, action, next);
+  return (state, action) => {
+    const nextState = reducer(state, action);
     return Object.assign({}, state, nextState);
   };
 };

--- a/test/compose.spec.ts
+++ b/test/compose.spec.ts
@@ -9,10 +9,12 @@ describe("compose", () => {
     expect(typeof compose([])).toBe("function");
   });
   it("throws an error if the supplied reducers are not an array", () => {
-    expect(() => compose({} as any)).toThrowError("Reducers must be an array");
+    expect(() => compose({} as ComposableReducer<never, never>[])).toThrowError(
+      "Reducers must be an array"
+    );
   });
   it("throws an error if the supplied reducers are not an array of functions", () => {
-    expect(() => compose([{} as any])).toThrowError(
+    expect(() => compose([{} as ComposableReducer<never, never>])).toThrowError(
       'Reducer at position "0" is not a function'
     );
   });


### PR DESCRIPTION
Remove middlewares erroneously accepting next only to pass it on to the next reducer, which means that if that reducer doesn't handle next correctly, it could inadvertently stop a composition early